### PR TITLE
Support PHP 8 and Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,6 @@
     "name": "johnwilhite/laravel-flare-scrubber",
     "description": "Request Data Scrubber for Laravel Flare Reporting",
     "type": "laravel-package",
-    "require": {
-        "facade/ignition": "^2.0"
-    },
     "license": "MIT",
     "autoload": {
         "psr-4": {
@@ -17,5 +14,8 @@
                 "FlareScrubber\\FlareScrubberProvider"
             ]
         }
+    },
+    "require": {
+        "spatie/laravel-ignition": "^1.0"
     }
 }

--- a/src/FlareScrubberProvider.php
+++ b/src/FlareScrubberProvider.php
@@ -3,8 +3,8 @@
 namespace FlareScrubber;
 
 use Illuminate\Support\ServiceProvider;
-use Facade\FlareClient\Report;
-use Facade\Ignition\Facades\Flare;
+use Spatie\FlareClient\Report;
+use Spatie\LaravelIgnition\Facades\Flare;
 
 class FlareScrubberProvider extends ServiceProvider
 {


### PR DESCRIPTION
The readme for the "facade/ignition" package says that when upgrading to Laravel 8+, the "facade/ignition" dependency should be replaced by "spatie/laravel-ignition".
https://github.com/facade/ignition#using-laravel-8-or-above

The readme for the "spatie/laravel-ignition" says (slightly differently) that their package is for "Laravel 8 and 9 applications running on PHP 8.0 and above," and that "facade/ignition" is "for Laravel 5.x, 6.x or 7.x or old PHP versions."
https://github.com/spatie/laravel-ignition

On Laravel 9, "johnwhilhite/laravel-flare-scrubber" will not even install due to conflicting dependencies between the package and Laravel 9.